### PR TITLE
Last preparations for 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,3 @@ script:
   - ./vendor/bin/phpstan analyse --no-interaction --no-progress
   - ./vendor/bin/psalm
   - ./vendor/bin/infection
-  - ./vendor/bin/roave-backward-compatibility-check --from=1.0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ script:
   - ./vendor/bin/phpstan analyse --no-interaction --no-progress
   - ./vendor/bin/psalm
   - ./vendor/bin/infection
+  - ./vendor/bin/roave-backward-compatibility-check --from=1.0.1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently maintained by [Niklas Schöllhorn](https://github.com/mrpixeldream), t
 The suggested installation method is via [composer](https://getcomposer.org/):
 
 ```sh
-php composer.phar require ocramius/lazy-property:1.0.*
+composer require ocramius/lazy-property
 ```
 
 ## Use case

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.2",
         "vimeo/psalm": "^3.1",
-        "infection/infection": "^0.12.2",
-        "roave/backward-compatibility-check": "^2.1"
+        "infection/infection": "^0.12.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,55 @@
 {
-    "name":              "ocramius/lazy-property",
-    "description":       "A library that provides lazy instantiation logic for object properties",
-    "type":              "library",
-    "license":           "MIT",
-    "homepage":          "https://github.com/Ocramius/LazyProperty",
-    "minimum-stability": "stable",
-    "keywords":          [
-        "lazy",
-        "lazy loading",
-        "lazy instantiation",
-        "utility"
-    ],
-    "authors": [
-        {
-            "name":     "Marco Pivetta",
-            "email":    "ocramius@gmail.com",
-            "homepage": "http://ocramius.github.io/"
-        }
-    ],
-    "require": {
-        "php": "^7.3"
+  "name": "ocramius/lazy-property",
+  "description": "A library that provides lazy instantiation logic for object properties",
+  "type": "library",
+  "license": "MIT",
+  "homepage": "https://github.com/Ocramius/LazyProperty",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "keywords": [
+    "lazy",
+    "lazy loading",
+    "lazy instantiation",
+    "utility"
+  ],
+  "authors": [
+    {
+      "name": "Marco Pivetta",
+      "email": "ocramius@gmail.com",
+      "homepage": "http://ocramius.github.io/"
     },
-    "require-dev": {
-        "phpunit/phpunit":           "^8.0.4",
-        "squizlabs/php_codesniffer": "^3.4.0",
-        "doctrine/coding-standard": "^5.0",
-        "phpstan/phpstan": "^0.11.2",
-        "vimeo/psalm": "^3.1",
-        "infection/infection": "^0.12.2"
-    },
-    "autoload": {
-        "psr-4": {
-            "LazyProperty\\": "src/LazyProperty"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "LazyPropertyTestAsset\\": "tests/LazyPropertyTestAsset",
-            "LazyPropertyTest\\": "tests/LazyPropertyTest"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0.x-dev"
-        }
+    {
+      "name": "Niklas Schöllhorn",
+      "email": "schoellhorn.niklas@gmail.com",
+      "role": "Maintainer"
     }
+  ],
+  "require": {
+    "php": "^7.3"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^8.0.4",
+    "squizlabs/php_codesniffer": "^3.4.0",
+    "doctrine/coding-standard": "^5.0",
+    "phpstan/phpstan": "^0.11.2",
+    "vimeo/psalm": "^3.1",
+    "infection/infection": "^0.12.2",
+    "roave/backward-compatibility-check": "^2.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "LazyProperty\\": "src/LazyProperty"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "LazyPropertyTestAsset\\": "tests/LazyPropertyTestAsset",
+      "LazyPropertyTest\\": "tests/LazyPropertyTest"
+    }
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0.x-dev"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,54 +1,54 @@
 {
-  "name": "ocramius/lazy-property",
-  "description": "A library that provides lazy instantiation logic for object properties",
-  "type": "library",
-  "license": "MIT",
-  "homepage": "https://github.com/Ocramius/LazyProperty",
-  "minimum-stability": "stable",
-  "keywords": [
-    "lazy",
-    "lazy loading",
-    "lazy instantiation",
-    "utility"
-  ],
-  "authors": [
-    {
-      "name": "Marco Pivetta",
-      "email": "ocramius@gmail.com",
-      "homepage": "http://ocramius.github.io/"
+    "name": "ocramius/lazy-property",
+    "description": "A library that provides lazy instantiation logic for object properties",
+    "type": "library",
+    "license": "MIT",
+    "homepage": "https://github.com/Ocramius/LazyProperty",
+    "minimum-stability": "stable",
+    "keywords": [
+        "lazy",
+        "lazy loading",
+        "lazy instantiation",
+        "utility"
+    ],
+    "authors": [
+        {
+            "name": "Marco Pivetta",
+            "email": "ocramius@gmail.com",
+            "homepage": "http://ocramius.github.io/"
+        },
+        {
+            "name": "Niklas Schöllhorn",
+            "email": "schoellhorn.niklas@gmail.com",
+            "role": "Maintainer"
+        }
+    ],
+    "require": {
+        "php": "^7.3"
     },
-    {
-      "name": "Niklas Schöllhorn",
-      "email": "schoellhorn.niklas@gmail.com",
-      "role": "Maintainer"
+    "require-dev": {
+        "phpunit/phpunit": "^8.0.4",
+        "squizlabs/php_codesniffer": "^3.4.0",
+        "doctrine/coding-standard": "^5.0",
+        "phpstan/phpstan": "^0.11.2",
+        "vimeo/psalm": "^3.1",
+        "infection/infection": "^0.12.2",
+        "roave/backward-compatibility-check": "^2.1"
+    },
+    "autoload": {
+        "psr-4": {
+            "LazyProperty\\": "src/LazyProperty"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "LazyPropertyTestAsset\\": "tests/LazyPropertyTestAsset",
+            "LazyPropertyTest\\": "tests/LazyPropertyTest"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
-  ],
-  "require": {
-    "php": "^7.3"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^8.0.4",
-    "squizlabs/php_codesniffer": "^3.4.0",
-    "doctrine/coding-standard": "^5.0",
-    "phpstan/phpstan": "^0.11.2",
-    "vimeo/psalm": "^3.1",
-    "infection/infection": "^0.12.2",
-    "roave/backward-compatibility-check": "^2.1"
-  },
-  "autoload": {
-    "psr-4": {
-      "LazyProperty\\": "src/LazyProperty"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "LazyPropertyTestAsset\\": "tests/LazyPropertyTestAsset",
-      "LazyPropertyTest\\": "tests/LazyPropertyTest"
-    }
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "1.0.x-dev"
-    }
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
   "type": "library",
   "license": "MIT",
   "homepage": "https://github.com/Ocramius/LazyProperty",
-  "minimum-stability": "dev",
-  "prefer-stable": true,
+  "minimum-stability": "stable",
   "keywords": [
     "lazy",
     "lazy loading",


### PR DESCRIPTION
I've added [roave/backward-compatibility-check](https://github.com/Roave/BackwardCompatibilityCheck/) to make sure we catch all bc breaks in new versions.  
In addition, I have adapted the README to make sure the recommended installation method installs the current version. 

After this PR was merged, we should be fully ready for 2.0.0.