### PR TITLE
Add roave/backward-compatibility-check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: false
 php:
   - 7.3
 
+before_install:
+  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
 before_script:
   - composer self-update
   - composer update --prefer-source
@@ -15,3 +18,4 @@ script:
   - ./vendor/bin/phpstan analyse --no-interaction --no-progress
   - ./vendor/bin/psalm
   - ./vendor/bin/infection
+  - ./vendor/bin/roave-backward-compatibility-check

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.2",
         "vimeo/psalm": "^3.1",
-        "infection/infection": "^0.12.2"
+        "infection/infection": "^0.12.2",
+        "roave/backward-compatibility-check": "^2.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Added roave/backward-compatibility-check to dependencies as well as travis build to be sure we don't push BC breaks in minor/patch versions. This will automatically make Travis fail if a PR introduces BC breaks.